### PR TITLE
fix: exclude bundle manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "nprogress": "^0.2.0",
     "offline-plugin": "^5.0.6",
     "prismjs": "^1.15.0",
-    "saber": "^0.2.8",
+    "saber": "^0.2.11",
     "saber-generator-feed": "^0.0.2",
     "saber-plugin-google-analytics": "^0.0.3",
     "typeface-fredericka-the-great": "^0.0.54",

--- a/saber-node.js
+++ b/saber-node.js
@@ -7,7 +7,7 @@ exports.chainWebpack = function(config, context) {
           events: true
         },
         AppCache: false,
-        excludes: ['favicon.ico']
+        excludes: ['favicon.ico', '**/../bundle-manifest/**']
       }
     ])
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,7 +624,7 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
-"@babel/runtime@^7.2.0":
+"@babel/runtime@^7.3.1":
   version "7.3.1"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
   integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
@@ -5421,17 +5421,17 @@ saber-utils@^0.0.3:
   resolved "https://registry.npmjs.org/saber-utils/-/saber-utils-0.0.3.tgz#c5f81dd182faf6edd6f9f1b81484c589fbe952d6"
   integrity sha512-4spEvm0wyZ7SR81+UOnvuVWhKb7rzalzibYRqemLc57kuZLwZ4lhIE7nLMfFmnweI8m0vRq0I+aXVHEWK1ea/g==
 
-saber@^0.2.8:
-  version "0.2.8"
-  resolved "https://registry.npmjs.org/saber/-/saber-0.2.8.tgz#75ce0d44dced2e4b8a5de0f12c8d3c6e59815722"
-  integrity sha512-VI/VJ3WZpoIT8qWiVA2dfpGhe6dEMXK0GR80IiMiHfX7erm8Zg6KIDSr0FP25rEQQ8zdyo+8/Gq66Y2CjMSAmA==
+saber@^0.2.11:
+  version "0.2.11"
+  resolved "https://registry.npmjs.org/saber/-/saber-0.2.11.tgz#9b11ab47b9666ae5b7af1d19286e0116aad34ecc"
+  integrity sha512-1GcGMOtSMOFochX58/HxOECYvyPvJCHa+BsKhNGYho+/0C+ACMMWsn8VU8400FnZTDIRUmcumrbuYPI9a7Rc+A==
   dependencies:
     "@babel/core" "^7.2.2"
     "@babel/plugin-proposal-object-rest-spread" "^7.2.0"
     "@babel/plugin-syntax-dynamic-import" "^7.2.0"
     "@babel/plugin-transform-runtime" "^7.2.0"
     "@babel/preset-env" "^7.2.3"
-    "@babel/runtime" "^7.2.0"
+    "@babel/runtime" "^7.3.1"
     "@egoist/postcss-loader" "^3.0.2"
     "@intervolga/optimize-cssnano-plugin" "^1.0.6"
     babel-loader "^8.0.5"


### PR DESCRIPTION
Fix broken service worker, `bundle-manifest` is removed so there're no such files.

<img width="762" alt="2019-02-18 8 53 59" src="https://user-images.githubusercontent.com/8784712/52952419-66eba480-33bf-11e9-9b81-80361499a28b.png">
